### PR TITLE
CIにrubocopの実行を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,5 +41,8 @@ jobs:
           bundle exec rails db:create RAILS_ENV=test
           bundle exec rails db:migrate RAILS_ENV=test
 
+      - name: Run rubocop
+        run: bundle exec rubocop
+
       - name: Run RSpec
         run: bundle exec rspec


### PR DESCRIPTION
## 概要
GithubActionsのCIでrubocopの実行が抜けていたため追加する。

## やったこと
- ci.ymlにrubocopの実行コマンドを追加

## 検証したこと
- GithubActions上でrubocopが実行されていること