### PR TITLE
postテーブルから不要なカラムを削除、post_conditionsテーブル削除

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -65,8 +65,7 @@ class PostsController < ApplicationController
   end
 
   def post_params
-    params.require(:post).permit(:prefecture_id, :place_name, :category_id, :people_num, :dogs_num, :rating_id,
-                                 :review, condition_ids: [], images: []).merge(user_id: current_user.id)
+    params.require(:post).permit(:people_num, :dogs_num, :rating_id, :review, images: []).merge(user_id: current_user.id)
   end
 
   def set_post

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -3,23 +3,16 @@ class Post < ApplicationRecord
   has_many :comments, dependent: :destroy
   belongs_to :facility
 
-  has_many   :post_conditions, dependent: :destroy
-  has_many   :conditions, through: :post_conditions
   has_many_attached :images
 
   extend ActiveHash::Associations::ActiveRecordExtensions
-  belongs_to :prefecture
-  belongs_to :category
   belongs_to :rating
 
   with_options numericality: { other_than: 1, message: 'を入力してください' } do
-    validates :prefecture_id
-    validates :category_id
     validates :rating_id
   end
 
   with_options presence: true do
-    validates :place_name
     validates :people_num
     validates :dogs_num
     validates :review

--- a/db/migrate/20231122043601_remove_columns_from_posts.rb
+++ b/db/migrate/20231122043601_remove_columns_from_posts.rb
@@ -1,0 +1,7 @@
+class RemoveColumnsFromPosts < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :posts, :prefecture_id, :integer
+    remove_column :posts, :place_name, :string
+    remove_column :posts, :category_id, :integer
+  end
+end

--- a/db/migrate/20231122044130_drop_post_conditions.rb
+++ b/db/migrate/20231122044130_drop_post_conditions.rb
@@ -1,0 +1,5 @@
+class DropPostConditions < ActiveRecord::Migration[7.1]
+  def change
+    drop_table :post_conditions
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_11_21_000003) do
+ActiveRecord::Schema[7.1].define(version: 2023_11_22_043601) do
   create_table "active_storage_attachments", charset: "utf8mb3", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_11_22_043601) do
+ActiveRecord::Schema[7.1].define(version: 2023_11_22_044130) do
   create_table "active_storage_attachments", charset: "utf8mb3", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -85,15 +85,6 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_22_043601) do
     t.index ["facility_id"], name: "index_facility_conditions_on_facility_id"
   end
 
-  create_table "post_conditions", charset: "utf8mb3", force: :cascade do |t|
-    t.bigint "post_id", null: false
-    t.bigint "condition_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["condition_id"], name: "index_post_conditions_on_condition_id"
-    t.index ["post_id"], name: "index_post_conditions_on_post_id"
-  end
-
   create_table "posts", charset: "utf8mb3", force: :cascade do |t|
     t.integer "people_num", null: false
     t.integer "dogs_num", null: false
@@ -129,8 +120,6 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_22_043601) do
   add_foreign_key "facilities", "users"
   add_foreign_key "facility_conditions", "conditions"
   add_foreign_key "facility_conditions", "facilities"
-  add_foreign_key "post_conditions", "conditions"
-  add_foreign_key "post_conditions", "posts"
   add_foreign_key "posts", "facilities"
   add_foreign_key "posts", "users"
 end


### PR DESCRIPTION
close #11 
postテーブルから不要なカラムを削除、post_conditionsテーブル削除が完了しましたので、ご確認よろしくお願いいたします。

## 実施したこと
- postテーブルから不要なカラムを削除
  - prefecture_id
  - place_name
  - category_id
- post_conditionsテーブル削除(conditionテーブルの繋がる先をfacilityテーブルに変更したため)

## 実行結果
**※レビュー指摘修正後に再試行した結果に書き換えました**
- 不要なカラムを削除、Post_conditionsテーブルがなくてもPostが保存できることを確認
　(ビュー、facilityとpostの関連付け保存ができているかなどは次issueにて実施)
![image](https://github.com/ChisatoMatoba/odekake-with-dogs/assets/149556430/87233502-40f4-43d5-b281-83b51f990142)
(略)
![image](https://github.com/ChisatoMatoba/odekake-with-dogs/assets/149556430/da65ada9-b63d-429d-88b2-ab8f1cc07ca3)


- db:migrate:status
Post_conditionsテーブルが削除されている
![image](https://github.com/ChisatoMatoba/odekake-with-dogs/assets/149556430/224fcd85-4d35-428e-a947-a65dab5442d5)

