### PR TITLE
施設詳細ページで施設に紐づく投稿を表示する

### DIFF
--- a/app/views/facilities/show.html.erb
+++ b/app/views/facilities/show.html.erb
@@ -62,7 +62,7 @@
     <div class="row mbr-gallery">
       <!-- 画像（postの数だけ) -->
       <% @facility.posts.each do |post| %>
-        <%= render "shared/gallery", post: post, facility: post.facility %>
+        <%= render "shared/gallery", post:, facility: post.facility %>
       <% end %>
     </div>
   </div>

--- a/app/views/facilities/show.html.erb
+++ b/app/views/facilities/show.html.erb
@@ -54,7 +54,7 @@
     <%# /ログイン者のみ投稿ボタン表示 %>
 
     <%# この施設の投稿一覧 %>
-    <h2 class="page-heading">
+    <h2 class="page-heading" id="facility-posts">
       <br><span class="bg-color"><%= "~#{@facility.place_name}のおでかけ情報一覧~"%></span>
     </h2>
 

--- a/app/views/facilities/show.html.erb
+++ b/app/views/facilities/show.html.erb
@@ -52,6 +52,19 @@
       </div>
     <% end %>
     <%# /ログイン者のみ投稿ボタン表示 %>
+
+    <%# この施設の投稿一覧 %>
+    <h2 class="page-heading">
+      <br><span class="bg-color"><%= "~#{@facility.place_name}のおでかけ情報一覧~"%></span>
+    </h2>
+
+    <!-- photo -->
+    <div class="row mbr-gallery">
+      <!-- 画像（postの数だけ) -->
+      <% @facility.posts.each do |post| %>
+        <%= render "shared/gallery", post: post, facility: post.facility %>
+      <% end %>
+    </div>
   </div>
 </div>
 

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -67,7 +67,7 @@
               </div>
               <!-- 画像（postの数だけ) -->
               <% @posts.each do |post| %>
-                <%= render "shared/gallery", post: post, facility: post.facility %>
+                <%= render "shared/gallery", post:, facility: post.facility %>
               <% end %>
             </div>
           </div>
@@ -79,7 +79,7 @@
             <div class="tab-pane fade" id="<%= area_name[1] %>" role="tabpanel" aria-labelledby="<%= area_name[2] %>" data-bs-target="#<%= area_name[1] %>" tabindex="0">
               <div class="row mbr-gallery">
                 <% @areas[area_name].each do |post| %>
-                  <%= render "shared/gallery", post: post, facility: post.facility %>
+                  <%= render "shared/gallery", post:, facility: post.facility %>
                 <% end %>
               </div>
             </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -11,7 +11,7 @@
       <tbody>
         <tr>
           <th class="detail-item display-7">施設名</th>
-          <td class="detail-value display-7"><%= @facility.place_name %></td>
+          <td class="detail-value display-7"><%= link_to @facility.place_name, facility_path(@facility) + "#facility-posts" %></td>
         </tr>
         <tr>
           <th class="detail-item display-7">所在地</th>
@@ -99,9 +99,9 @@
       </ul>
     </div>
 
-<!--
-  <a href="#" class="another-posts"><%= @facility.prefecture.name %>のおでかけ情報をもっと見る</a>
--->
+    <div class="d-grid gap-2 col-6 mx-auto">
+      <%= link_to "#{@facility.place_name}のおでかけ情報をもっと見る", facility_path(@facility) + "#facility-posts", class: "btn btn-warning" %>
+    </div>
   </div>
 </div>
 

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -11,7 +11,7 @@
       <tbody>
         <tr>
           <th class="detail-item display-7">施設名</th>
-          <td class="detail-value display-7"><%= link_to @facility.place_name, facility_path(@facility) + "#facility-posts" %></td>
+          <td class="detail-value display-7"><%= link_to @facility.place_name, facility_path(@facility, anchor: "facility-posts") %></td>
         </tr>
         <tr>
           <th class="detail-item display-7">所在地</th>
@@ -100,7 +100,7 @@
     </div>
 
     <div class="d-grid gap-2 col-6 mx-auto">
-      <%= link_to "#{@facility.place_name}のおでかけ情報をもっと見る", facility_path(@facility) + "#facility-posts", class: "btn btn-warning" %>
+      <%= link_to "#{@facility.place_name}のおでかけ情報をもっと見る", facility_path(@facility, anchor: "facility-posts"), class: "btn btn-warning" %>
     </div>
   </div>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -63,7 +63,7 @@
       <div class="row mbr-gallery">
         <!-- 画像（postの数だけ) -->
         <% @posts.each do |post| %>
-          <%= render "shared/gallery", post: post, facility: post.facility %>
+          <%= render "shared/gallery", post:, facility: post.facility %>
         <% end %>
       </div>
     </div>


### PR DESCRIPTION
close #14 
施設詳細ページで施設に紐づく投稿を表示する　が完了しましたので、ご確認よろしくお願いいたします。

## 実施したこと
- 施設詳細ページ下部に、その施設も紐づく投稿一覧を表示する
- 各投稿詳細画面からも施設詳細画面に飛べるようにする

## 特記事項
- issueの下記についてですが、投稿一覧表示と同じ部分テンプレート(app/views/shared/_gallery.html.erb)を使いたく、施設名・県名・評価星も表示したままにしています。もしissue通りに表示した方がよければ、どのような書き方がいいか助言頂けないでしょうか。

> カード形式で、表示する情報は画像/ユーザー名

## 実行結果
施設詳細画面
　→投稿クリックで投稿詳細画面へ
　→「しせつのおでかけ情報をもっと見る」で施設詳細画面へ
　→投稿クリックで投稿詳細画面へ
　→施設情報の施設名欄をクリックで施設詳細画面へ
[実行結果動画](https://github.com/ChisatoMatoba/odekake-with-dogs/assets/149556430/086bc0f0-2b90-4070-ba74-35b482c7859b)

