### PR TITLE
新規投稿画面にタグフォーム追加

### DIFF
--- a/app/assets/stylesheets/posts/new.css
+++ b/app/assets/stylesheets/posts/new.css
@@ -227,3 +227,11 @@
 .inc {
   font-size: 13px;
 }
+
+.form-any {
+  background: #ccc;
+  border-radius: 2px;
+  color: #fff;
+  font-size: 12px;
+  padding: 2px 4px;
+}

--- a/app/assets/stylesheets/posts/new.css
+++ b/app/assets/stylesheets/posts/new.css
@@ -228,7 +228,7 @@
   font-size: 13px;
 }
 
-.form-any {
+.optional-form {
   background: #ccc;
   border-radius: 2px;
   color: #fff;

--- a/app/assets/stylesheets/posts/new.css
+++ b/app/assets/stylesheets/posts/new.css
@@ -30,7 +30,7 @@
 }
 
 /* 共通 */
-.indispensable {
+.required-form {
   background: #ea352d;
   margin-left: 8px;
   padding: 3px;

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -13,21 +13,21 @@
   <div class="form-group">
     <div class='form-text-wrap'>
       <label class="form-text">ニックネーム</label>
-      <span class="indispensable">必須</span>
+      <span class="required-form">必須</span>
     </div>
     <%= f.text_area :nickname, class:"input-default", id:"nickname", placeholder:"例) いぬ山いぬ子", maxlength:"40" %>
   </div>
   <div class="form-group">
     <div class='form-text-wrap'>
       <label class="form-text">メールアドレス</label>
-      <span class="indispensable">必須</span>
+      <span class="required-form">必須</span>
     </div>
     <%= f.email_field :email, class:"input-default", id:"email", placeholder:"PC・携帯どちらでも可", autofocus: true %>
   </div>
   <div class="form-group">
     <div class='form-text-wrap'>
       <label class="form-text">パスワード</label>
-      <span class="indispensable">必須</span>
+      <span class="required-form">必須</span>
     </div>
     <%= f.password_field :password, class:"input-default", id:"password", placeholder:"6文字以上の半角英数字" %>
     <p class='info-text'>※英字と数字の両方を含めて設定してください</p>
@@ -35,7 +35,7 @@
   <div class="form-group">
     <div class='form-text-wrap'>
       <label class="form-text">パスワード(確認)</label>
-      <span class="indispensable">必須</span>
+      <span class="required-form">必須</span>
     </div>
     <%= f.password_field :password_confirmation, class:"input-default", id:"password-confirmation", placeholder:"同じパスワードを入力して下さい" %>
   </div>
@@ -51,7 +51,7 @@
   <div class="form-group">
     <div class='form-text-wrap'>
       <label class="form-text">生年月日</label>
-      <span class="indispensable">必須</span>
+      <span class="required-form">必須</span>
     </div>
     <div class='input-birth-wrap'>
       <%= raw sprintf(

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -14,14 +14,14 @@
   <div class="form-group">
     <div class='form-text-wrap'>
       <label class="form-text">メールアドレス</label>
-      <span class="indispensable">必須</span>
+      <span class="required-form">必須</span>
     </div>
     <%= f.email_field :email, class:"input-default", id:"email", placeholder:"PC・携帯どちらでも可", autofocus: true %>
   </div>
   <div class="form-group">
     <div class='form-text-wrap'>
       <label class="form-text">パスワード</label>
-      <span class="indispensable">必須</span>
+      <span class="required-form">必須</span>
     </div>
     <%= f.password_field :password, class:"input-default", id:"password", placeholder:"" %>
   </div>

--- a/app/views/dogs/new.html.erb
+++ b/app/views/dogs/new.html.erb
@@ -9,22 +9,22 @@
     <div class="new-items">
       <div class="weight-bold-text">
         お名前
-        <span class="indispensable">必須</span>
+        <span class="required-form">必須</span>
       </div>
       <%= f.text_area :dog_name, class:"items-text", id:"item-name", placeholder:"(必須 40文字まで)", maxlength:"40" %>
       <div class="weight-bold-text">
         生年月日
-        <span class="indispensable">必須</span>
+        <span class="required-form">必須</span>
       </div>
       <%= f.date_select(:dog_birthday, prefix: "dog_birthday", prompt:"---",use_month_numbers:true, start_year:Time.now.year, end_year:1990, date_separator:'  /  ') %>
       <div class="weight-bold-text">
         犬種
-        <span class="indispensable">必須</span>
+        <span class="required-form">必須</span>
       </div>
       <%= f.collection_select(:breed_id, Breed.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
       <div class="weight-bold-text">
         男の子／女の子
-        <span class="indispensable">必須</span>
+        <span class="required-form">必須</span>
       </div>
       <%= f.collection_select(:gender_id, Gender.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
     </div>
@@ -33,7 +33,7 @@
     <div class="img-upload">
       <div class="weight-bold-text">
         わんちゃんの画像
-        <span class="indispensable">必須、1枚</span>
+        <span class="required-form">必須、1枚</span>
       </div>
       <div id="previews"></div>
       <div class="click-upload">

--- a/app/views/facilities/_form.html.erb
+++ b/app/views/facilities/_form.html.erb
@@ -22,8 +22,8 @@
       </div>
       <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
       <div class="weight-bold-text">
-        施設の条件
-        <span class="form-any">任意、複数選択可</span>
+        施設の条件(複数選択可)
+        <span class="optional-form">任意</span>
       </div>
       <div class="multi-check">
         <%= f.collection_check_boxes(:condition_ids, Condition.all, :id, :category, {}, {class:"check-box", id:"entry-condition"}) do |c| %>

--- a/app/views/facilities/_form.html.erb
+++ b/app/views/facilities/_form.html.erb
@@ -8,17 +8,17 @@
     <div class="new-items">
       <div class="weight-bold-text">
         都道府県
-        <span class="indispensable">必須</span>
+        <span class="required-form">必須</span>
       </div>
       <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"prefecture"}) %>
       <div class="weight-bold-text">
         施設名
-        <span class="indispensable">必須</span>
+        <span class="required-form">必須</span>
       </div>
       <%= f.text_area :place_name, class:"items-text", id:"item-name", placeholder:"施設の名前（必須 40文字まで)", maxlength:"40" %>
       <div class="weight-bold-text">
         カテゴリー
-        <span class="indispensable">必須</span>
+        <span class="required-form">必須</span>
       </div>
       <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
       <div class="weight-bold-text">

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -78,8 +78,8 @@
     <%# タグ付け %>
     <div class="tag-form">
       <div class="weight-bold-text">
-        タグ
-        <span class="form-any">任意、複数可</span>
+        タグ(複数登録可)
+        <span class="optional-form">任意</span>
       </div>
       タグを入力してください
     </div>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -36,23 +36,23 @@
     <%# 口コミ %>
     <div class="weight-bold-text">
       <span>訪れた人数</span>
-      <span class="indispensable">必須</span>
+      <span class="required-form">必須</span>
     </div>
     <%= f.text_field :people_num, class:"items-text", id:"item-name", placeholder:"例）3" %>
     <div class="weight-bold-text">
       <span>一緒に訪れたワンちゃんの数</span>
-      <span class="indispensable">必須</span>
+      <span class="required-form">必須</span>
     </div>
     <%= f.text_field :dogs_num, class:"items-text", id:"item-name", placeholder:"例）3" %>
     <div class="weight-bold-text">
       満足度（非常に不満〜非常に満足）
-      <span class="indispensable">必須</span>
+      <span class="required-form">必須</span>
     </div>
     <%= f.collection_select(:rating_id, Rating.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
     <div class="items-explain">
       <div class="weight-bold-text">
         感想・おすすめポイント
-        <span class="indispensable">必須</span>
+        <span class="required-form">必須</span>
       </div>
       <%= f.text_area :review, class:"items-text", id:"item-info", placeholder:"施設を訪れた感想を書いてください！（必須 1,000文字まで）" ,rows:"7" ,maxlength:"1000" %>
     </div>
@@ -62,7 +62,7 @@
     <div class="img-upload">
       <div class="weight-bold-text">
         おでかけ画像
-        <span class="indispensable">必須</span>
+        <span class="required-form">必須</span>
       </div>
       <div id="previews"></div>
       <div class="click-upload">

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -75,6 +75,20 @@
     </div>
     <%# /おでかけ画像 %>
 
+    <%# タグ付け %>
+    <div class="tag-form">
+      <div class="weight-bold-text">
+        タグ
+        <span class="form-any">任意、複数可</span>
+      </div>
+      タグを入力してください
+    </div>
+    <%# フォームはJSなしバージョンのみの仕様 %>
+    <% (1..5).each do |i| %>
+      <%= f.text_field "tag_#{i}", id:"tag_#{i}" %>
+    <% end %>
+    <%# /タグ付け %>
+
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "投稿する" ,class:"sell-btn" %>


### PR DESCRIPTION
#40
新規投稿画面にタグフォーム追加　が完了しましたので、ご確認よろしくお願いいたします。

## 実施したこと
- 新規投稿画面にタグフォームを追加

## 新規投稿画面
![image](https://github.com/ChisatoMatoba/odekake-with-dogs/assets/149556430/bc0e06df-0960-4363-8f40-5859ad529023)

## 次の計画
一応、記しておきます。
1. （今ココ）Post#newで同じフォーム内にタグ入力フォームを設置
2. Post#createでPostの保存とTagの保存(orすでに存在するタグがあれば探し出す)→Postとタグを関連付け
3. 編集、削除、検索などの機能はTags_conntrollerで実装