### PR TITLE
タグと関連付けて投稿保存

### DIFF
--- a/app/assets/stylesheets/shared/ all.css.erb
+++ b/app/assets/stylesheets/shared/ all.css.erb
@@ -1673,3 +1673,10 @@ a {
   background-color: #260a30;
   overflow: hidden;
 }
+
+.alert {
+  position: fixed;
+  top: 110px;
+  left: 50%;
+  transform: translateX(-50%);
+}

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -69,7 +69,7 @@ class PostsController < ApplicationController
   end
 
   def set_post
-    @post = @facility.posts.includes(images_attachments: :blob).find_by(params[:id])
+    @post = @facility.posts.includes(images_attachments: :blob).find_by(id: params[:id])
   end
 
   def set_facility

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -23,8 +23,15 @@ class PostsController < ApplicationController
   def create
     @post = @facility.posts.build(post_params)
     if @post.save
+      (1..5).each do |i|
+        tag_name = params[:post]["tag_#{i}"].strip
+        unless tag_name.empty?
+          tag = Tag.find_or_create_by(name: tag_name)
+          @post.tags << tag unless @post.tags.include?(tag)
+        end
+      end
       # 登録できたらその投稿の詳細画面へ
-      redirect_to facility_post_path(@facility, @post)
+      redirect_to facility_post_path(@facility, @post), notice: '投稿が成功しました。'
     else
       render :new, status: :unprocessable_entity
     end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,6 +23,11 @@
   </head>
 
   <body>
+    <% if flash.notice.present? %>
+      <div class="alert alert-success">
+        <%= flash.notice %>
+      </div>
+    <% end %>
     <%= yield %>
     <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.8/dist/umd/popper.min.js" integrity="sha384-I7E8VVD/ismYTF4hNIPjVp/Zjvgyol6VFvRkX/vR+Vc4jQkC+hVqc2pM8ODewa9r" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.min.js" integrity="sha384-Rx+T1VzGupg4BHQYs2gCW9It+akI2MM/mndMCy36UVfodzcJcF0GGLxZIzObiEfa" crossorigin="anonymous"></script>  </body>


### PR DESCRIPTION
#34 
タグと関連付けて投稿保存が完了しましたので、ご確認よろしくお願いいたします。

## 実施したこと
- 投稿保存時にタグの作成および中間テーブルでの紐付けが行えるようにする
- 同名のタグがあればそれを紐付けし、無ければ新規作成するような処理を入れる
- 上記はpost#create内で行う

## 実行結果
[![Image from Gyazo](https://i.gyazo.com/91ad9191270b3ffdae0836ac1323fef5.gif)](https://gyazo.com/91ad9191270b3ffdae0836ac1323fef5)

ログ
<details><summary>(前略)</summary>

![image](https://github.com/ChisatoMatoba/odekake-with-dogs/assets/149556430/61536e92-80f7-4c03-8a3d-9cdd5cdfadb0)
![image](https://github.com/ChisatoMatoba/odekake-with-dogs/assets/149556430/47c25f90-941c-47e0-922f-27beb98b24f6)

</details>

"綺麗"というタグはすでに存在するのでそのタグを割当て↓
![image](https://github.com/ChisatoMatoba/odekake-with-dogs/assets/149556430/1c3bbc30-a2de-48e0-b3ee-036e8ca3f10a)
"素敵"というタグはないので新しく作成して割当て↓
![image](https://github.com/ChisatoMatoba/odekake-with-dogs/assets/149556430/b6f37efc-d8f9-4fde-a5aa-b1ec0f7a6ee8)
