### PR TITLE
自分のユーザー詳細画面からのみ愛犬登録できるようにする

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG RUBY_VERSION=3.1.4
 FROM registry.docker.com/library/ruby:$RUBY_VERSION-slim
 
 # Rails app lives here
-WORKDIR /rails
+WORKDIR /odekake_with_dogs
 
 # Install packages needed to build gems
 RUN apt-get update -qq && \

--- a/app/controllers/dogs_controller.rb
+++ b/app/controllers/dogs_controller.rb
@@ -1,5 +1,4 @@
 class DogsController < ApplicationController
-  before_action :authenticate_user!
   before_action :move_to_index, only: %i[new create]
 
   def new

--- a/app/controllers/dogs_controller.rb
+++ b/app/controllers/dogs_controller.rb
@@ -1,6 +1,6 @@
 class DogsController < ApplicationController
   before_action :authenticate_user!
-  before_action :move_to_index
+  before_action :move_to_index, only: %i[new create]
 
   def new
     @dog = Dog.new
@@ -18,9 +18,7 @@ class DogsController < ApplicationController
   private
 
   def move_to_index
-    return if user_signed_in?
-
-    redirect_to action: :index
+    redirect_to root_path if current_user.id.to_s != params[:user_id]
   end
 
   def dog_params

--- a/app/controllers/dogs_controller.rb
+++ b/app/controllers/dogs_controller.rb
@@ -1,4 +1,5 @@
 class DogsController < ApplicationController
+  before_action :authenticate_user!
   before_action :move_to_index, only: %i[new create]
 
   def new

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -52,9 +52,12 @@
         </table>
       <% end %>
       <%# ログイン中かつ自分のページなら、愛犬登録ボタンを表示 %>
-      <div class="title d-grid col-3 mx-auto">
-        <%= link_to "！愛犬登録はこちら！", new_user_dog_path(@user.id), class: "btn btn-warning display-7" %>
-      </div>
+      <% if user_signed_in? && current_user.id == @user.id %>
+        <div class="title d-grid col-3 mx-auto">
+          <%= link_to "！愛犬登録はこちら！", new_user_dog_path(@user.id), class: "btn btn-warning display-7" %>
+        </div>
+      <% end %>
+
       <h2 class="page-heading">
         <br><span class="bg-color"><%= "~#{@user.nickname}さんの投稿一覧~"%></span>
       </h2>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     build: .
     command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     volumes:
-      - .:/myapp
+      - .:/odekake_with_dogs
     ports:
       - "3000:3000"
     depends_on:


### PR DESCRIPTION
close #27 
自分のユーザー詳細画面からのみ愛犬登録できるようにする が完了しましたので、ご確認よろしくお願いいたします。

## 実施したこと
- ユーザー詳細画面において、ログイン中かつ自分のユーザー詳細画面のときのみ「愛犬登録」ボタンを表示するように変更
- dogsコントローラーにて、ログイン中かつ自分のユーザーidにネストしたdogs#new(create)以外のパスにはアクセスできずルートパスにリダイレクトされるように変更

## 実行結果
①自分のユーザー詳細画面からは愛犬登録ボタンから登録画面へ遷移できる
②自分以外のユーザー詳細画面には愛犬登録ボタンが表示されない

https://github.com/ChisatoMatoba/odekake-with-dogs/assets/149556430/7fc4e873-4b55-4eb8-814d-29a3d8ad057c

