### PR TITLE
詳細画面にタグ表示

### DIFF
--- a/app/assets/stylesheets/shared/ all.css.erb
+++ b/app/assets/stylesheets/shared/ all.css.erb
@@ -1680,3 +1680,58 @@ a {
   left: 50%;
   transform: translateX(-50%);
 }
+
+.tag-item li {
+	display: inline-block;
+}
+
+.tag-item a {
+	line-height: 26px;
+	position: relative;
+	display: inline-block;
+	height: 26px;
+	margin: 0 10px 10px 0;
+	padding: 0 20px 0 23px;
+	-webkit-transition: color 0.2s;
+	        transition: color 0.2s;
+	text-decoration: none;
+	color: #455a64;
+	border-radius: 3px 0 0 3px;
+	background: #40d0ed;
+}
+
+.tag-item a::before, .tag-item a::after {
+	background: #fafcfc;/*背景色*/
+}
+
+.tag-item a::before {
+	position: absolute;
+	top: 10px;
+	left: 10px;
+	width: 6px;
+	height: 6px;
+	content: '';
+	border-radius: 10px;
+}
+
+.tag-item a::after {
+	position: absolute;
+	top: -2px;
+	right: -6px;
+	width: 0;
+	height: 0;
+	content: '';
+	border-width: 15px 0 15px 8px;
+	border-style: solid;
+	border-color: transparent transparent transparent #cfd8dc;
+	border-radius: 4px;
+}
+
+.tag-item a:hover {
+	color: #ffffff;
+	background-color: #ec407a;
+}
+
+.tag-item a:hover::after {
+	border-left-color: #ec407a;
+}

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -63,6 +63,14 @@
             </div>
           </td>
         </tr>
+        <tr>
+          <th class="detail-item display-7">タグ</th>
+          <td class="detail-value tag-item">
+            <% @post.tags.each do |tag| %>
+              <%= link_to "#{tag.name} ( #{tag.posts.count} )", "#" %>
+            <% end %>
+          </td>
+        </tr>
       </tbody>
     </table>
     <%# /ユーザーレビュー %>


### PR DESCRIPTION
close #34 
詳細画面にタグ表示が完了しましたので、ご確認よろしくお願いいたします。

## 実施したこと
- 投稿詳細画面に、その投稿と紐づいているタグを表示
- リンク形式にしているが、他issueにて、そのタグがつけられている投稿を一覧表示できる機能を付ける予定

## 実行結果
[動画(gif)](https://i.gyazo.com/e216c64d136a325ed8f20759029d56c2.gif)
