### PR TITLE
タグを保存前に削除(取りやめ)する機能

### DIFF
--- a/app/javascript/tags.js
+++ b/app/javascript/tags.js
@@ -20,10 +20,22 @@ document.addEventListener('turbo:load', function() {
   }
 
   // タグを表示する関数
-  function createBadge(text) {
+  function createBadge(text, index) {
     const badge = document.createElement('div');
     badge.textContent = text;
     badge.classList.add('badge');
+
+    // 削除ボタンを追加
+    const deleteBtn = document.createElement('button');
+    deleteBtn.textContent = '✕'; // バツマーク
+    deleteBtn.onclick = function() {
+      // タグと関連する隠しフィールドを削除
+      badge.remove();
+      document.getElementsByName(`post[tags_attributes][${index}][name]`)[0].remove();
+      document.getElementsByName(`post[tags_attributes][${index}][id]`)[0].remove();
+    };
+
+    badge.appendChild(deleteBtn);
     tagContainer.appendChild(badge);
   }
 

--- a/app/javascript/tags.js
+++ b/app/javascript/tags.js
@@ -8,7 +8,7 @@ document.addEventListener('turbo:load', function() {
   function addTag() {
     const inputText = inputTag.value;
     if (inputText) {
-      createBadge(inputText);
+      createBadge(inputText, tagIndex);
       createHiddenInput(inputText, tagIndex);
 
       // インデックスを増やす
@@ -29,10 +29,13 @@ document.addEventListener('turbo:load', function() {
     const deleteBtn = document.createElement('button');
     deleteBtn.textContent = '✕'; // バツマーク
     deleteBtn.onclick = function() {
-      // タグと関連する隠しフィールドを削除
+      // タグを削除
       badge.remove();
-      document.getElementsByName(`post[tags_attributes][${index}][name]`)[0].remove();
-      document.getElementsByName(`post[tags_attributes][${index}][id]`)[0].remove();
+      // 対応するname,idフィールドを空欄にする(コントローラーで空欄は除外されるため)
+      const nameInput = document.querySelector(`input[name='post[tags_attributes][${index}][name]']`);
+      const idInput = document.querySelector(`input[name='post[tags_attributes][${index}][id]']`);
+      if (nameInput) nameInput.value = '';
+      if (idInput) idInput.value = '';
     };
 
     badge.appendChild(deleteBtn);

--- a/app/javascript/tags.js
+++ b/app/javascript/tags.js
@@ -19,6 +19,17 @@ document.addEventListener('turbo:load', function() {
     }
   }
 
+  // タグを削除する関数
+  function deleteTag(badge, index) {
+    // タグを削除
+    badge.remove();
+    // 対応するname,idフィールドを空欄にする(コントローラーで空欄は除外されるため)
+    const nameInput = document.querySelector(`input[name='post[tags_attributes][${index}][name]']`);
+    const idInput = document.querySelector(`input[name='post[tags_attributes][${index}][id]']`);
+    if (nameInput) nameInput.value = '';
+    if (idInput) idInput.value = '';
+  }
+
   // タグを表示する関数
   function createBadge(text, index) {
     const badge = document.createElement('div');
@@ -29,13 +40,7 @@ document.addEventListener('turbo:load', function() {
     const deleteBtn = document.createElement('button');
     deleteBtn.textContent = '✕'; // バツマーク
     deleteBtn.onclick = function() {
-      // タグを削除
-      badge.remove();
-      // 対応するname,idフィールドを空欄にする(コントローラーで空欄は除外されるため)
-      const nameInput = document.querySelector(`input[name='post[tags_attributes][${index}][name]']`);
-      const idInput = document.querySelector(`input[name='post[tags_attributes][${index}][id]']`);
-      if (nameInput) nameInput.value = '';
-      if (idInput) idInput.value = '';
+      deleteTag(badge, index);
     };
 
     badge.appendChild(deleteBtn);


### PR DESCRIPTION
#35 
タグを保存前に削除(取りやめ)する機能の追加が完了しましたので、ご確認よろしくお願いいたします。

## 実施したこと
- 新規投稿画面で、タグを追加後に、タグの右に表示されている✗をクリックしたらタグが削除される
- 投稿ボタン押下で保存すると、削除したタグの情報は保存されないようにする

## 特記事項
- 編集の方はまだJS対応できていないので、新規投稿でのみ動作確認しました
- accepts_nested_attributes_forの"_destroy"をtrueにして削除する方法も考えましたが、データ保存がうまくできず断念しました。
（name, idを空欄に書き換えて、その後のコントローラーで空欄が除外されるときに除外されるようにしました）

## 実行結果
