### PR TITLE
編集画面にタグのJSを適用

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -46,6 +46,8 @@ class PostsController < ApplicationController
   end
 
   def update
+    binding.pry
+
     # 空欄でないタグフォームのタグ名を配列に
     tag_names = post_params[:tags_attributes].values.map { |tag_attr| tag_attr[:name].strip }.reject(&:empty?)
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -46,8 +46,6 @@ class PostsController < ApplicationController
   end
 
   def update
-    binding.pry
-
     # 空欄でないタグフォームのタグ名を配列に
     tag_names = post_params[:tags_attributes].values.map { |tag_attr| tag_attr[:name].strip }.reject(&:empty?)
 

--- a/app/javascript/tags.js
+++ b/app/javascript/tags.js
@@ -80,7 +80,7 @@ document.addEventListener('turbo:load', function() {
   function setupDeleteTagButtons() {
     // ✗ボタンがクリックされたとき
     document.querySelectorAll('.delete-tag-btn').forEach(function(button) {
-      const index = button.getAttribute('data-tag-button-id');
+      const index = button.getAttribute('data-tag-button-index');
       button.addEventListener('click', function() {
         const tagElement = document.getElementById(`existing-tag-${index}`);
         // タグの削除

--- a/app/javascript/tags.js
+++ b/app/javascript/tags.js
@@ -66,7 +66,7 @@ document.addEventListener('turbo:load', function() {
     document.querySelector('form').appendChild(hiddenIdInput);
   }
 
-  // 既存のタグを表示(編集画面)
+  // 既存のタグの隠しフィールドを作成(編集画面)
   function addExistingTagsHiddenFields() {
     const existingTags = document.querySelectorAll('.badge');
     existingTags.forEach(function(tagElement, index) {
@@ -107,7 +107,7 @@ document.addEventListener('turbo:load', function() {
     }
   }
 
-  // 既存のタグを表示(編集画面)
+  // 既存のタグの隠しフィールドを作成(編集画面)
   addExistingTagsHiddenFields();
   // 既存のタグの削除(編集画面)
   setupDeleteTagButtons();

--- a/app/javascript/tags.js
+++ b/app/javascript/tags.js
@@ -69,13 +69,9 @@ document.addEventListener('turbo:load', function() {
   // 既存のタグの隠しフィールドを追加する処理
   function addExistingTagsHiddenFields() {
     const existingTags = document.querySelectorAll('.badge');
-    console.log(existingTags);
     existingTags.forEach(function(tagElement, index) {
       const tagId = tagElement.getAttribute('data-tag-id');
       const tagName = tagElement.getAttribute('data-tag-name');
-
-      console.log(tagId);
-      console.log(tagName);
 
       // 既存のタグの隠しフィールドを追加する
       const hiddenInput = document.createElement('input');
@@ -94,6 +90,21 @@ document.addEventListener('turbo:load', function() {
 
   function setupDeleteTagButtons() {
     // ✗ボタンがクリックされたとき
+    document.querySelectorAll('.delete-tag-btn').forEach(function(button) {
+      const index = button.getAttribute('data-tag-button-id');
+      button.addEventListener('click', function() {
+        const tagElement = document.getElementById(`existing-tag-${index}`);
+        if (tagElement) {
+          // タグを削除
+          tagElement.remove();
+          // 対応する隠しフィールドを空にする
+          const nameInput = document.querySelector(`input[name='post[tags_attributes][${index}][name]']`);
+          const idInput = document.querySelector(`input[name='post[tags_attributes][${index}][id]']`);
+          if (nameInput) nameInput.value = '';
+          if (idInput) idInput.value = '';
+        }
+      });
+    });
   }
 
   // エンターかボタンクリックでタグを追加する関数

--- a/app/javascript/tags.js
+++ b/app/javascript/tags.js
@@ -52,6 +52,7 @@ document.addEventListener('turbo:load', function() {
 
   // 隠しフィールドを追加する関数
   function createHiddenInput(value, index) {
+    // タグのnameフィールド
     const hiddenInput = document.createElement('input');
     hiddenInput.type = 'hidden';
     hiddenInput.name = `post[tags_attributes][${index}][name]`;
@@ -65,44 +66,25 @@ document.addEventListener('turbo:load', function() {
     document.querySelector('form').appendChild(hiddenIdInput);
   }
 
-  // 編集画面で既存のタグを表示する関数
-  // 既存のタグの隠しフィールドを追加する処理
+  // 既存のタグを表示(編集画面)
   function addExistingTagsHiddenFields() {
     const existingTags = document.querySelectorAll('.badge');
     existingTags.forEach(function(tagElement, index) {
-      const tagId = tagElement.getAttribute('data-tag-id');
       const tagName = tagElement.getAttribute('data-tag-name');
-
-      // 既存のタグの隠しフィールドを追加する
-      const hiddenInput = document.createElement('input');
-      hiddenInput.type = 'hidden';
-      hiddenInput.name = `post[tags_attributes][${index}][name]`;
-      hiddenInput.value = tagName;
-      document.querySelector('form').appendChild(hiddenInput);
-
-      const hiddenIdInput = document.createElement('input');
-      hiddenIdInput.type = 'hidden';
-      hiddenIdInput.name = `post[tags_attributes][${index}][id]`;
-      hiddenIdInput.value = tagId;
-      document.querySelector('form').appendChild(hiddenIdInput);
-    });
+      // 隠しフィールドを作成
+      createHiddenInput(tagName, index)
+  });
   }
 
+  // 既存のタグの削除(編集画面)
   function setupDeleteTagButtons() {
     // ✗ボタンがクリックされたとき
     document.querySelectorAll('.delete-tag-btn').forEach(function(button) {
       const index = button.getAttribute('data-tag-button-id');
       button.addEventListener('click', function() {
         const tagElement = document.getElementById(`existing-tag-${index}`);
-        if (tagElement) {
-          // タグを削除
-          tagElement.remove();
-          // 対応する隠しフィールドを空にする
-          const nameInput = document.querySelector(`input[name='post[tags_attributes][${index}][name]']`);
-          const idInput = document.querySelector(`input[name='post[tags_attributes][${index}][id]']`);
-          if (nameInput) nameInput.value = '';
-          if (idInput) idInput.value = '';
-        }
+        // タグの削除
+        if (tagElement) deleteTag(tagElement, index);
       });
     });
   }

--- a/app/javascript/tags.js
+++ b/app/javascript/tags.js
@@ -2,7 +2,10 @@ document.addEventListener('turbo:load', function() {
   const inputTag = document.getElementById('input-tag');
   const tagContainer = document.getElementById('tag-container');
   const addButton = document.getElementById('add-tag-button');
-  let tagIndex = 0; // タグのインデックスを管理する変数
+
+  // 既存のタグの数を取得し、tagIndexに設定
+  const existingTags = document.querySelectorAll('.badge');
+  let tagIndex = existingTags.length;
 
   // タグを追加する関数
   function addTag() {
@@ -62,6 +65,37 @@ document.addEventListener('turbo:load', function() {
     document.querySelector('form').appendChild(hiddenIdInput);
   }
 
+  // 編集画面で既存のタグを表示する関数
+  // 既存のタグの隠しフィールドを追加する処理
+  function addExistingTagsHiddenFields() {
+    const existingTags = document.querySelectorAll('.badge');
+    console.log(existingTags);
+    existingTags.forEach(function(tagElement, index) {
+      const tagId = tagElement.getAttribute('data-tag-id');
+      const tagName = tagElement.getAttribute('data-tag-name');
+
+      console.log(tagId);
+      console.log(tagName);
+
+      // 既存のタグの隠しフィールドを追加する
+      const hiddenInput = document.createElement('input');
+      hiddenInput.type = 'hidden';
+      hiddenInput.name = `post[tags_attributes][${index}][name]`;
+      hiddenInput.value = tagName;
+      document.querySelector('form').appendChild(hiddenInput);
+
+      const hiddenIdInput = document.createElement('input');
+      hiddenIdInput.type = 'hidden';
+      hiddenIdInput.name = `post[tags_attributes][${index}][id]`;
+      hiddenIdInput.value = tagId;
+      document.querySelector('form').appendChild(hiddenIdInput);
+    });
+  }
+
+  function setupDeleteTagButtons() {
+    // ✗ボタンがクリックされたとき
+  }
+
   // エンターかボタンクリックでタグを追加する関数
   function setupTagInputHandlers() {
     // 入力フィールドにユーザーが入力したとき(エンターキー押下時の処理)
@@ -80,6 +114,10 @@ document.addEventListener('turbo:load', function() {
     }
   }
 
+  // 既存のタグを表示(編集画面)
+  addExistingTagsHiddenFields();
+  // 既存のタグの削除(編集画面)
+  setupDeleteTagButtons();
   // タグ追加実行
   setupTagInputHandlers();
 });

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -92,7 +92,7 @@
       <% @post.tags.each_with_index do |tag, i| %>
         <div class="badge existing-tag" id="existing-tag-<%= i %>" data-tag-id="<%= tag.id %>" data-tag-name="<%= tag.name %>">
           <%= tag.name %>
-          <button type="button" class="delete-tag-btn" data-tag-id="<%= i %>">✕</button>
+          <button type="button" class="delete-tag-btn" data-tag-button-id="<%= i %>">✕</button>
         </div>
       <% end %>
     </div>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -92,7 +92,7 @@
       <% @post.tags.each_with_index do |tag, i| %>
         <div class="badge existing-tag" id="existing-tag-<%= i %>" data-tag-id="<%= tag.id %>" data-tag-name="<%= tag.name %>">
           <%= tag.name %>
-          <button type="button" class="delete-tag-btn" data-tag-button-id="<%= i %>">✕</button>
+          <button type="button" class="delete-tag-btn" data-tag-button-index="<%= i %>">✕</button>
         </div>
       <% end %>
     </div>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -88,7 +88,14 @@
       <input type="text" id="input-tag" placeholder="テキストを入力">
       <button id="add-tag-button" type="button">タグを追加</button>
     </div>
-    <div id="tag-container"></div>
+    <div id="tag-container">
+      <% @post.tags.each_with_index do |tag, i| %>
+        <div class="badge existing-tag" id="existing-tag-<%= i %>" data-tag-id="<%= tag.id %>" data-tag-name="<%= tag.name %>">
+          <%= tag.name %>
+          <button type="button" class="delete-tag-btn" data-tag-id="<%= i %>">✕</button>
+        </div>
+      <% end %>
+    </div>
     <%# /タグ付け %>
 
     <%# 下部ボタン %>


### PR DESCRIPTION
close #35 
編集画面にタグのJSを適用が完了しましたので、ご確認よろしくお願いいたします。

## 実施したこと
- 編集画面に遷移したときに、すでにタグを保存している場合は、タグ入力フォームの下に表示する
  - 各タグの右の✗をクリックすると、そのタグが削除される
- 既存のタグの他に新たに入力フォームから入力して追加・削除もできるようにする
- 投稿ボタンをクリックすると、編集画面に表示されているタグだけが保存され、(DBと)詳細画面に反映される

## 実行結果
[実行動画](
https://github.com/ChisatoMatoba/odekake-with-dogs/assets/149556430/874940bf-e494-48e7-a930-63f620dcdd83)

編集前：["美味しい", "楽しい"]
編集後：["楽しい", "嬉しい", "新しいタグ追加"]

① "美味しい"を削除
② "楽しい", "嬉しい"をpost_tagsで紐づけ
③ "新しいタグ追加"を新規作成して紐づけ
![スクリーンショット 2023-12-04 16 29 58](https://github.com/ChisatoMatoba/odekake-with-dogs/assets/149556430/fb371977-4aa5-49c1-880e-cfc61d2b67bb)

![image](https://github.com/ChisatoMatoba/odekake-with-dogs/assets/149556430/9399a901-e65a-44ab-93f3-e11d501d9175)
