### PR TITLE
同じタグの投稿を一覧表示(タグ詳細画面)

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -2,4 +2,8 @@ class TagsController < ApplicationController
   def index
     @tags = Tag.left_joins(:posts).group(:id).order('COUNT(posts.id) DESC')
   end
+
+  def show
+    @tag = Tag.find(params[:id])
+  end
 end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -4,6 +4,6 @@ class TagsController < ApplicationController
   end
 
   def show
-    @tag = Tag.find(params[:id])
+    @tag = Tag.includes(posts: [:facility, :user, { images_attachments: :blob }]).find_by(id: params[:id])
   end
 end

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -67,7 +67,7 @@
           <th class="detail-item display-7">タグ</th>
           <td class="detail-value tag-item">
             <% @post.tags.each do |tag| %>
-              <%= link_to "#{tag.name} ( #{tag.posts.count} )", "#" %>
+              <%= link_to "#{tag.name} ( #{tag.posts.count} )", tag_path(tag.id) %>
             <% end %>
           </td>
         </tr>

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -9,7 +9,7 @@
 
     <div class="tag-item">
       <% @tags.each do |tag| %>
-          <%= link_to "#{tag.name} ( #{tag.posts.count} )", "#" %>
+          <%= link_to "#{tag.name} ( #{tag.posts.count} )", tag_path(tag.id) %>
       <% end %>
     </div>
 

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -1,0 +1,21 @@
+<%= render "shared/header" %>
+
+<div class="tags-main">
+  <div class="user__wrapper">
+    <h2 class="page-heading">
+      <span class="bg-color">~<%= @tag.name %>のタグがつけられている投稿一覧~</span>
+    </h2>
+
+    <div class="row mbr-gallery">
+      <!-- 画像（postの数だけ) -->
+      <% @tag.posts.each do |post| %>
+        <%= render "shared/gallery", post:, facility: post.facility %>
+      <% end %>
+    </div>
+
+
+
+  </div>
+</div>
+
+<%= render "shared/footer" %>

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -2,19 +2,23 @@
 
 <div class="tags-main">
   <div class="user__wrapper">
-    <h2 class="page-heading">
-      <span class="bg-color">~<%= @tag.name %>のタグがつけられている投稿一覧~</span>
+    <h2 style="text-align: center;">
+      <span class="bg-color">~<%= @tag.name %>タグのお出かけ情報一覧~</span>
     </h2>
 
     <div class="row mbr-gallery">
-      <!-- 画像（postの数だけ) -->
-      <% @tag.posts.each do |post| %>
-        <%= render "shared/gallery", post:, facility: post.facility %>
+      <% if @tag.posts.present? %>
+        <%# その地域の投稿がある場合 %>
+        <% @tag.posts.each do |post| %>
+          <%= render "shared/gallery", post:, facility: post.facility %>
+        <% end %>
+      <% else %>
+        <%# その地域の投稿がない場合 %>
+        <p style="text-align: center; margin-top: 50px;">
+          <%= @tag.name %>のタグがつけられているおでかけ情報がまだありません
+        </p>
       <% end %>
     </div>
-
-
-
   </div>
 </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,5 +10,5 @@ Rails.application.routes.draw do
   resources :users, only: :show do
     resources :dogs, only: [:new, :create]
   end
-  resources :tags, only: [:index]
+  resources :tags, only: [:index, :show]
 end


### PR DESCRIPTION
close #42 
同じタグの投稿を一覧表示(タグ詳細画面)が完了しましたので、ご確認よろしくお願いいたします。

## 実施したこと
- タグ詳細画面を作成し、投稿詳細画面・タグ一覧画面のタグボタンをクリックしたら遷移できるようにする
- タグに紐づく投稿がある場合は、他のギャラリーと同じように、投稿を一覧表示する
- タグに紐づく投稿がない場合は、「(タグ名)のタグがつけられているおでかけ情報がまだありません」と表示する

## 実行結果

https://github.com/ChisatoMatoba/odekake-with-dogs/assets/149556430/ec0d92af-ff3e-4edc-ae66-397a25493bfd

