### PR TITLE
新規施設登録のsystem spec

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -63,6 +63,8 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.include Devise::Test::IntegrationHelpers, type: :system
 end
 
 Capybara.default_driver = :selenium_chrome_headless

--- a/spec/system/facility_registration_spec.rb
+++ b/spec/system/facility_registration_spec.rb
@@ -11,7 +11,24 @@ RSpec.describe '施設新規登録', type: :system do
     # 正しいユーザー情報を入力する
     fill_in 'email', with: user.email
     fill_in 'password', with: user.password
-    # ログインボタンを押す
+    # ログインボタンを押す(rootへ移動)
+    find('input[name="commit"]').click
+
+    # 施設一覧・新規投稿ボタンが表示されることを確認する
+    expect(page).to have_content('施設一覧・新規投稿')
+    # 施設一覧・新規投稿ボタンをクリックする
+    click_on '施設一覧・新規投稿'
+    # 施設一覧ページへ遷移することを確認する
+    expect(page).to have_current_path(facilities_path)
+    # 施設登録画面へボタンをクリックする
+    click_on '施設登録画面へ'
+    # 施設登録ページへ遷移することを確認する
+    expect(page).to have_current_path(new_facility_path)
+    # 施設情報を入力する
+    select '北海道', from: 'prefecture'
+    fill_in 'item-name', with: 'テスト施設'
+    select '宿泊', from: 'item-category'
+    # 登録ボタンを押す
     find('input[name="commit"]').click
   end
 end

--- a/spec/system/facility_registration_spec.rb
+++ b/spec/system/facility_registration_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe '施設新規登録', type: :system do
     expect(page).to have_current_path(facilities_path)
     # 施設登録画面へボタンをクリックする
     click_on '施設登録画面へ'
+
     # 施設登録ページへ遷移することを確認する
     expect(page).to have_current_path(new_facility_path)
     # 施設情報を入力する
@@ -30,8 +31,11 @@ RSpec.describe '施設新規登録', type: :system do
     select '宿泊', from: 'item-category'
     # 登録ボタンを押す
     find('input[name="commit"]').click
+
     # その施設の詳細ページへ遷移することを確認する
     new_facility = Facility.last
     expect(page).to have_current_path(facility_path(new_facility))
+    # 登録した施設名がページに表示されていることを確認
+    expect(page).to have_text('テスト施設')
   end
 end

--- a/spec/system/facility_registration_spec.rb
+++ b/spec/system/facility_registration_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe '施設新規登録', type: :system do
+  before do
+
+  end
+
+  it '正しい情報を入力すれば' do
+
+  end
+
+  it 'ログイン中にはユーザーログアウトができてトップページに移動する' do
+
+  end
+
+
+  private
+
+
+
+end

--- a/spec/system/facility_registration_spec.rb
+++ b/spec/system/facility_registration_spec.rb
@@ -1,15 +1,17 @@
 require 'rails_helper'
 
 RSpec.describe '施設新規登録', type: :system do
-  before do
-    # テスト用のユーザーを作成
-    @user = FactoryBot.create(:user)
-  end
+  # テスト用のユーザーを作成
+  let!(:user) { FactoryBot.create(:user) }
 
   it '正しい情報を入力すれば施設を登録できて、施設詳細画面に移動する' do
-
+    # ログイン処理を行う
+    # ログインページへ遷移する
+    visit new_user_session_path
+    # 正しいユーザー情報を入力する
+    fill_in 'email', with: user.email
+    fill_in 'password', with: user.password
+    # ログインボタンを押す
+    find('input[name="commit"]').click
   end
-
-  private
-
 end

--- a/spec/system/facility_registration_spec.rb
+++ b/spec/system/facility_registration_spec.rb
@@ -30,5 +30,8 @@ RSpec.describe '施設新規登録', type: :system do
     select '宿泊', from: 'item-category'
     # 登録ボタンを押す
     find('input[name="commit"]').click
+    # その施設の詳細ページへ遷移することを確認する
+    new_facility = Facility.last
+    expect(page).to have_current_path(facility_path(new_facility))
   end
 end

--- a/spec/system/facility_registration_spec.rb
+++ b/spec/system/facility_registration_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe '施設新規登録', type: :system do
     fill_in 'item-name', with: 'テスト施設'
     select '宿泊', from: 'item-category'
     # 登録ボタンを押す
-    find('input[name="commit"]').click
+    click_on '登録する'
 
     # その施設の詳細ページへ遷移することを確認する
     new_facility = Facility.last

--- a/spec/system/facility_registration_spec.rb
+++ b/spec/system/facility_registration_spec.rb
@@ -4,16 +4,14 @@ RSpec.describe '施設新規登録', type: :system do
   # テスト用のユーザーを作成
   let!(:user) { FactoryBot.create(:user) }
 
-  it '正しい情報を入力すれば施設を登録できて、施設詳細画面に移動する' do
-    # ログイン処理を行う
-    # ログインページへ遷移する
-    visit new_user_session_path
-    # 正しいユーザー情報を入力する
-    fill_in 'email', with: user.email
-    fill_in 'password', with: user.password
-    # ログインボタンを押す(rootへ移動)
-    find('input[name="commit"]').click
+  before do
+    # 事前にサインインしておく
+    sign_in user
+  end
 
+  it '正しい情報を入力すれば施設を登録できて、施設詳細画面に移動する' do
+    # トップページに移動する
+    visit root_path
     # 施設一覧・新規投稿ボタンが表示されることを確認する
     expect(page).to have_content('施設一覧・新規投稿')
     # 施設一覧・新規投稿ボタンをクリックする

--- a/spec/system/facility_registration_spec.rb
+++ b/spec/system/facility_registration_spec.rb
@@ -2,20 +2,14 @@ require 'rails_helper'
 
 RSpec.describe '施設新規登録', type: :system do
   before do
-
+    # テスト用のユーザーを作成
+    @user = FactoryBot.create(:user)
   end
 
-  it '正しい情報を入力すれば' do
+  it '正しい情報を入力すれば施設を登録できて、施設詳細画面に移動する' do
 
   end
-
-  it 'ログイン中にはユーザーログアウトができてトップページに移動する' do
-
-  end
-
 
   private
-
-
 
 end


### PR DESCRIPTION
#57 
新規施設登録のsystem specが完了しましたので、ご確認よろしくお願いいたします。

## 実施したこと
- ログイン中に正しい情報を入力すれば施設を登録でき、その施設の詳細画面に遷移することを確認する
- 施設の新規登録画面への遷移ルートが少し特殊なため、トップページからの遷移のテストも実施した
  - トップページ -> 施設一覧画面 -> 施設新規登録画面

## 実施していないこと
- 異常系は実施していない

## 実行結果
![image](https://github.com/ChisatoMatoba/odekake-with-dogs/assets/149556430/e3e8e444-c385-41e1-8be0-1ce751c967f9)
