### PR TITLE
施設編集・削除のsystem spec

### DIFF
--- a/spec/factories/facilities.rb
+++ b/spec/factories/facilities.rb
@@ -1,4 +1,8 @@
 FactoryBot.define do
   factory :facility do
+    prefecture { Prefecture.find_by(name: '北海道') }
+    place_name { Faker::Name.initials(number: 2) }
+    category   { Category.find_by(name: '宿泊') }
+    association :user
   end
 end

--- a/spec/factories/facilities.rb
+++ b/spec/factories/facilities.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :facility do
-    prefecture { Prefecture.find_by(name: '北海道') }
+    prefecture { Prefecture.all.reject { |p| p.id == 1 }.sample }
     place_name { Faker::Name.initials(number: 2) }
-    category   { Category.find_by(name: '宿泊') }
+    category { Category.all.reject { |p| p.id == 1 }.sample }
     association :user
   end
 end

--- a/spec/factories/facilities.rb
+++ b/spec/factories/facilities.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :facility do
-    prefecture { Prefecture.all.reject { |p| p.id == 1 }.sample }
+    prefecture { Prefecture.where.not(id: 1).sample }
     place_name { Faker::Name.initials(number: 2) }
-    category { Category.all.reject { |p| p.id == 1 }.sample }
+    category { Category.where.not(id: 1).sample }
     association :user
   end
 end

--- a/spec/system/facility_edit_del_spec.rb
+++ b/spec/system/facility_edit_del_spec.rb
@@ -11,6 +11,9 @@ RSpec.describe '施設新規登録', type: :system do
     sign_in user
   end
 
-  it '正しい情報を入力すれば施設を登録できて、施設詳細画面に移動する' do
+  it '正しい情報を入力すれば施設を編集できて、施設詳細画面に移動する' do
+  end
+
+  it '自分が作成した施設を削除できる' do
   end
 end

--- a/spec/system/facility_edit_del_spec.rb
+++ b/spec/system/facility_edit_del_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe '施設新規登録', type: :system do
   # テスト用のユーザーを作成
   let!(:user) { FactoryBot.create(:user) }
   # テスト用の施設を作成
-  let!(:facility) { FactoryBot.create(:facility, user: user) }
+  let!(:facility) { FactoryBot.create(:facility, user: user, place_name: 'テスト施設') }
 
   before do
     # 事前にサインインしておく

--- a/spec/system/facility_edit_del_spec.rb
+++ b/spec/system/facility_edit_del_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe '施設新規登録', type: :system do
   # テスト用のユーザーを作成
   let!(:user) { FactoryBot.create(:user) }
   # テスト用の施設を作成
-  let!(:facility) { FactoryBot.create(:facility) }
+  let!(:facility) { FactoryBot.create(:facility, user: user) }
 
   before do
     # 事前にサインインしておく
@@ -12,6 +12,12 @@ RSpec.describe '施設新規登録', type: :system do
   end
 
   it '正しい情報を入力すれば施設を編集できて、施設詳細画面に移動する' do
+    # 施設詳細画面へ遷移する
+    visit facility_path(facility)
+    # 編集ボタンをクリックする
+    click_on '編集'
+    # 施設編集ページへ遷移することを確認する
+    expect(page).to have_current_path(edit_facility_path(facility))
   end
 
   it '自分が作成した施設を削除できる' do

--- a/spec/system/facility_edit_del_spec.rb
+++ b/spec/system/facility_edit_del_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe '施設新規登録', type: :system do
+  # テスト用のユーザーを作成
+  let!(:user) { FactoryBot.create(:user) }
+  # テスト用の施設を作成
+  let!(:facility) { FactoryBot.create(:facility) }
+
+  before do
+    # 事前にサインインしておく
+    sign_in user
+  end
+
+  it '正しい情報を入力すれば施設を登録できて、施設詳細画面に移動する' do
+  end
+end

--- a/spec/system/facility_edit_del_spec.rb
+++ b/spec/system/facility_edit_del_spec.rb
@@ -18,6 +18,16 @@ RSpec.describe '施設新規登録', type: :system do
     click_on '編集'
     # 施設編集ページへ遷移することを確認する
     expect(page).to have_current_path(edit_facility_path(facility))
+    # 施設情報を変更する
+    fill_in 'item-name', with: '施設名変更テスト'
+    # 登録ボタンを押す
+    click_on '登録する'
+
+    # その施設の詳細ページへ遷移することを確認する
+    new_facility = Facility.last
+    expect(page).to have_current_path(facility_path(new_facility))
+    # 登録した施設名がページに表示されていることを確認
+    expect(page).to have_text('施設名変更テスト')
   end
 
   it '自分が作成した施設を削除できる' do

--- a/spec/system/facility_edit_del_spec.rb
+++ b/spec/system/facility_edit_del_spec.rb
@@ -30,6 +30,18 @@ RSpec.describe '施設新規登録', type: :system do
     expect(page).to have_text('施設名変更テスト')
   end
 
-  it '自分が作成した施設を削除できる' do
+  it '自分が作成した施設を削除できて、トップページに移動する' do
+    # 施設詳細画面へ遷移する
+    visit facility_path(facility)
+    # 削除ボタンをクリックする
+    click_on '削除'
+    # rootページへ遷移することを確認する
+    expect(page).to have_current_path(root_path)
+    # 施設一覧ページへ遷移する
+    visit facilities_path
+    # 「全国」の項目をクリックする
+    find('.prefecture-row', text: '全国').click
+    # 削除された施設がリストに表示されていないことを確認する
+    expect(page).not_to have_content(facility.place_name)
   end
 end


### PR DESCRIPTION
#57 
施設編集・削除のsystem specが完了しましたので、ご確認よろしくお願いいたします。

## 実施したこと
- 正しい情報を入力すれば施設を編集できて、施設詳細画面に移動することを確認
- 自分が作成した施設を削除できて、トップページに移動することを確認
　(削除されたことは、施設一覧画面へ遷移して全国タブの中に施設名がないことで確認する)

## 実施していないこと
- 異常系は実施していない

## 実行結果
![image](https://github.com/ChisatoMatoba/odekake-with-dogs/assets/149556430/a47858a3-5fb3-415f-8d40-afadbba5945b)
