### PR TITLE
施設検索のsystem spec

### DIFF
--- a/spec/system/facility_search_spec.rb
+++ b/spec/system/facility_search_spec.rb
@@ -21,12 +21,24 @@ RSpec.describe '施設検索', type: :system do
     # 検索結果欄と検索結果が表示されることを確認する
     expect(page).to have_content '検索結果'
     expect(page).to have_content 'テスト施設'
+    # 一致しない施設は表示されないことを確認する
+    expect(page).to have_no_content 'テスト宿泊地'
     # 施設名をクリックする
     click_on 'テスト施設'
     # テスト施設の詳細画面へ遷移することを確認する
     expect(page).to have_current_path(facility_path(facility))
     # クリックした施設名がページに表示されていることを確認
     expect(page).to have_text('テスト施設')
+  end
+
+  it '既存の施設のうち、入力した検索内容と部分的に一致する施設を検索でき、施設詳細へ遷移できる' do
+    # 検索フォームに入力する
+    fill_in '施設名', with: 'テスト'
+    click_on '検索'
+    # 検索結果欄と検索結果（部分一致）が表示されることを確認する
+    expect(page).to have_content '検索結果'
+    expect(page).to have_content 'テスト施設'
+    expect(page).to have_content 'テスト宿泊地'
   end
 
   it '存在しない施設名を入力すれば「お探しの施設はありません」と表示される' do

--- a/spec/system/facility_search_spec.rb
+++ b/spec/system/facility_search_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe '施設検索', type: :system do
+  # テスト用のユーザーを作成
+  let!(:user) { FactoryBot.create(:user) }
+  # テスト用の施設を作成
+  let!(:facility) { FactoryBot.create(:facility, user: user, place_name: 'テスト施設') }
+
+  before do
+    # 事前にサインインしておく
+    sign_in user
+  end
+
+  it '既存の施設名を入力すれば施設を検索できる' do
+  end
+
+  it '存在しない施設名を入力すれば「お探しの施設はありません」と表示される' do
+  end
+end

--- a/spec/system/facility_search_spec.rb
+++ b/spec/system/facility_search_spec.rb
@@ -5,15 +5,21 @@ RSpec.describe '施設検索', type: :system do
   let!(:user) { FactoryBot.create(:user) }
   # テスト用の施設を作成
   let!(:facility) { FactoryBot.create(:facility, user: user, place_name: 'テスト施設') }
+  let!(:facility_hokkaido) { FactoryBot.create(:facility, user: user, prefecture: '北海道') }
 
   before do
     # 事前にサインインしておく
     sign_in user
+    # 施設一覧画面へ遷移する
+    visit facilities_path
   end
 
   it '既存の施設名を入力すれば施設を検索できる' do
   end
 
   it '存在しない施設名を入力すれば「お探しの施設はありません」と表示される' do
+  end
+
+  it '検索結果に関わらず、一覧表示には常にすべての施設が表示される' do
   end
 end

--- a/spec/system/facility_search_spec.rb
+++ b/spec/system/facility_search_spec.rb
@@ -5,8 +5,6 @@ RSpec.describe '施設検索', type: :system do
   let!(:user) { FactoryBot.create(:user) }
   # テスト用の施設を作成
   let!(:facility) { FactoryBot.create(:facility, user: user, place_name: 'テスト施設') }
-  let!(:hokkaido) { Prefecture.find_by(name: '北海道') }
-  let!(:facility_hokkaido) { FactoryBot.create(:facility, user: user, prefecture: hokkaido, place_name: '札幌の公園') }
 
   before do
     # 事前にサインインしておく
@@ -39,6 +37,27 @@ RSpec.describe '施設検索', type: :system do
     expect(page).to have_content 'お探しの施設はありません'
   end
 
-  it '検索結果に関わらず、一覧表示には常にすべての施設が表示される' do
+  it '検索結果に関わらず、一覧表示には常にすべての施設が表示され、施設詳細へ遷移できる' do
+    # 検索フォームを入力する前
+    # facilityの都道府県名をクリックする
+    find('.prefecture-row', text: facility.prefecture.name).click
+    # 施設がリストに表示されていることを確認する
+    expect(page).to have_content('テスト施設')
+
+    # 検索
+    fill_in '施設名', with: 'フェイル施設'
+    click_on '検索'
+
+    # 検索後も同じ状況であることを確認する
+    # facilityの都道府県名をクリックする
+    find('.prefecture-row', text: facility.prefecture.name).click
+    # 施設がリストに表示されていることを確認する
+    expect(page).to have_content('テスト施設')
+    # 施設名をクリックする
+    click_on 'テスト施設'
+    # テスト施設の詳細画面へ遷移することを確認する
+    expect(page).to have_current_path(facility_path(facility))
+    # クリックした施設名がページに表示されていることを確認
+    expect(page).to have_text('テスト施設')
   end
 end

--- a/spec/system/facility_search_spec.rb
+++ b/spec/system/facility_search_spec.rb
@@ -14,7 +14,19 @@ RSpec.describe '施設検索', type: :system do
     visit facilities_path
   end
 
-  it '既存の施設名を入力すれば施設を検索できる' do
+  it '既存の施設名を入力すれば施設を検索でき、施設詳細へ遷移できる' do
+    # 検索フォームに入力する
+    fill_in '施設名', with: 'テスト施設'
+    click_on '検索'
+    # 検索結果欄と検索結果が表示されることを確認する
+    expect(page).to have_content '検索結果'
+    expect(page).to have_content 'テスト施設'
+    # 施設名をクリックする
+    click_on 'テスト施設'
+    # テスト施設の詳細画面へ遷移することを確認する
+    expect(page).to have_current_path(facility_path(facility))
+    # クリックした施設名がページに表示されていることを確認
+    expect(page).to have_text('テスト施設')
   end
 
   it '存在しない施設名を入力すれば「お探しの施設はありません」と表示される' do

--- a/spec/system/facility_search_spec.rb
+++ b/spec/system/facility_search_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe '施設検索', type: :system do
   let!(:user) { FactoryBot.create(:user) }
   # テスト用の施設を作成
   let!(:facility) { FactoryBot.create(:facility, user: user, place_name: 'テスト施設') }
-  let!(:facility_hokkaido) { FactoryBot.create(:facility, user: user, prefecture: '北海道') }
+  let!(:hokkaido) { Prefecture.find_by(name: '北海道') }
+  let!(:facility_hokkaido) { FactoryBot.create(:facility, user: user, prefecture: hokkaido, place_name: '札幌の公園') }
 
   before do
     # 事前にサインインしておく
@@ -30,6 +31,12 @@ RSpec.describe '施設検索', type: :system do
   end
 
   it '存在しない施設名を入力すれば「お探しの施設はありません」と表示される' do
+    # 検索フォームに入力する
+    fill_in '施設名', with: 'フェイル施設'
+    click_on '検索'
+    # 検索結果欄と警告が表示されることを確認する
+    expect(page).to have_content '検索結果'
+    expect(page).to have_content 'お探しの施設はありません'
   end
 
   it '検索結果に関わらず、一覧表示には常にすべての施設が表示される' do

--- a/spec/system/facility_search_spec.rb
+++ b/spec/system/facility_search_spec.rb
@@ -40,20 +40,23 @@ RSpec.describe '施設検索', type: :system do
 
   it '検索結果に関わらず、一覧表示には常にすべての施設が表示され、施設詳細へ遷移できる' do
     # 検索フォームを入力する前
-    # facilityの都道府県名をクリックする
-    find('.prefecture-row', text: facility.prefecture.name).click
+    # 全国の行をクリックする
+    find('.prefecture-row', text: '全国').click
     # 施設がリストに表示されていることを確認する
     expect(page).to have_content('テスト施設')
+    expect(page).to have_content('テスト宿泊地')
 
     # 検索
     fill_in '施設名', with: 'フェイル施設'
     click_on '検索'
 
     # 検索後も同じ状況であることを確認する
-    # facilityの都道府県名をクリックする
-    find('.prefecture-row', text: facility.prefecture.name).click
+    # 全国の行をクリックする
+    find('.prefecture-row', text: '全国').click
     # 施設がリストに表示されていることを確認する
     expect(page).to have_content('テスト施設')
+    expect(page).to have_content('テスト宿泊地')
+
     # 施設名をクリックする
     click_on 'テスト施設'
     # テスト施設の詳細画面へ遷移することを確認する

--- a/spec/system/facility_search_spec.rb
+++ b/spec/system/facility_search_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe '施設検索', type: :system do
   let!(:user) { FactoryBot.create(:user) }
   # テスト用の施設を作成
   let!(:facility) { FactoryBot.create(:facility, user: user, place_name: 'テスト施設') }
-  let!(:facility_2) { FactoryBot.create(:facility, user: user, place_name: 'テスト宿泊地') }
+  let!(:facility_sub) { FactoryBot.create(:facility, user: user, place_name: 'テスト宿泊地') }
 
   before do
     # 事前にサインインしておく
@@ -70,10 +70,10 @@ RSpec.describe '施設検索', type: :system do
     expect(page).to have_content('テスト宿泊地')
 
     # 施設名をクリックする
-    click_on 'テスト施設'
+    click_on 'テスト宿泊地'
     # テスト施設の詳細画面へ遷移することを確認する
-    expect(page).to have_current_path(facility_path(facility))
+    expect(page).to have_current_path(facility_path(facility_sub))
     # クリックした施設名がページに表示されていることを確認
-    expect(page).to have_text('テスト施設')
+    expect(page).to have_text('テスト宿泊地')
   end
 end

--- a/spec/system/facility_search_spec.rb
+++ b/spec/system/facility_search_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe '施設検索', type: :system do
   let!(:user) { FactoryBot.create(:user) }
   # テスト用の施設を作成
   let!(:facility) { FactoryBot.create(:facility, user: user, place_name: 'テスト施設') }
+  let!(:facility_2) { FactoryBot.create(:facility, user: user, place_name: 'テスト宿泊地') }
 
   before do
     # 事前にサインインしておく


### PR DESCRIPTION
close #57 
施設検索のsystem specが完了しましたので、ご確認よろしくお願いいたします。

## 実施したこと
 - 既存の施設名を入力すれば施設を検索でき、施設詳細へ遷移できることを確認
 - 存在しない施設名を入力すれば「お探しの施設はありません」と表示されることを確認
 - 検索結果に関わらず、一覧表示には常にすべての施設が表示され、施設詳細へ遷移できることを確認

## 実施していないこと
- 予期しない動作などの異常系は実施していない
- 共通化などは塩梅がわからず実施しませんでした。必要があればレビューにてご指摘お願いします。

## 実行結果
![image](https://github.com/ChisatoMatoba/odekake-with-dogs/assets/149556430/b2b147c3-c5a3-4222-a244-7d31161a0fad)
