### PR TITLE
Ransack導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -99,3 +99,5 @@ gem 'bootstrap'
 gem 'aws-sdk-s3', require: false
 
 gem 'rails-i18n'
+
+gem 'ransack'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -260,6 +260,10 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.0.6)
+    ransack (4.1.1)
+      activerecord (>= 6.1.5)
+      activesupport (>= 6.1.5)
+      i18n
     regexp_parser (2.8.1)
     reline (0.3.8)
       io-console (~> 0.5)
@@ -395,6 +399,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rails (~> 7.1.1)
   rails-i18n
+  ransack
   rspec-rails
   rubocop
   rubocop-rails

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -5,7 +5,8 @@ class PostsController < ApplicationController
 
   def index
     @facilities = Facility.includes(:post).order(:prefecture_id)
-    @posts = Post.includes(:user, :facility, images_attachments: :blob).order(created_at: :DESC)
+    @q = Post.ransack(params[:q]) # Ransackの検索オブジェクトを初期化
+    @posts = @q.result.includes(:user, :facility, images_attachments: :blob).order(created_at: :DESC) # 検索結果を取得
 
     @areas = {}
     # 投稿を地域ごとにグループ化する

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -23,4 +23,12 @@ class Post < ApplicationRecord
     validates :review
     validates :images, length: { minimum: 1, maximum: 5, message: 'は1枚以上5枚以下にしてください' }
   end
+
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[created_at dogs_num facility_id id id_value people_num rating_id review updated_at user_id]
+  end
+
+  def self.ransackable_associations(_auth_object = nil)
+    %(comments facility images_attachments images_blobs post_tags rating tags user)
+  end
 end

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -39,6 +39,40 @@
           </div>
         </div>
       </div>
+  </section>
+
+  <!-- 検索フォームセクション -->
+  <section class="gallery1 mbr-gallery cid-tOiHBd9Aax" id="gallery01-1l">
+    <div class="container-fluid search-form">
+      <!-- title -->
+      <div class="#">
+        <strong>検索フォーム</strong>
+      </div>
+      <!-- 一旦ransackの検索フォームが表示できたことだけ確認 -->
+      <div class="#">
+        <%= search_form_for(@q, url: root_path, method: :get, local: true) do |f| %>
+          <%= f.label :name, "Keyword" %>
+          <%= f.search_field :review %>
+          <%= f.submit "検索" %>
+        <% end %>
+      </div>
+    </div>
+  </section>
+
+  <!-- 検索結果セクション -->
+  <section data-bs-version="5.1" class="gallery1 mbr-gallery cid-tOiHBd9Aax" id="gallery01-1l">
+    <!-- photo -->
+    <div class="row mbr-gallery">
+      <%# 例 %>
+      <div class="col-12 col-md-6 col-lg-3 item gallery-image">
+        <%= image_tag("gallery.jpeg", class: "") %>
+      </div>
+      <%# 画像（postの数だけ) %>
+      <% @posts.each do |post| %>
+        <%= render "shared/gallery", post:, facility: post.facility %>
+      <% end %>
+    </div>
+  <section data-bs-version="5.1" class="gallery1 mbr-gallery cid-tOiHBd9Aax" id="gallery01-1l">
 
 <!--
       <%# photo %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -40,9 +40,10 @@
         </div>
       </div>
 
-      <!-- photo -->
+<!--
+      <%# photo %>
       <div class="row mbr-gallery">
-        <!-- タブ -->
+        <%# タブ %>
         <nav>
           <div class="nav nav-tabs" id="nav-tab" role="tablist">
             <button class="nav-link tab_change active" id="nav-zenkoku-tab" data-bs-toggle="tab" data-bs-target="#nav-zenkoku-content" type="button" role="tab" aria-controls="nav-zenkoku-content" aria-selected="true">全国</button>
@@ -56,16 +57,16 @@
             <button class="nav-link tab_change" id="nav-okinawa-tab" data-bs-toggle="tab" data-bs-target="#nav-okinawa-content" type="button" role="tab" aria-controls="nav-okinawa-content" aria-selected="false">沖縄</button>
           </div>
         </nav>
-        <!-- photo -->
+        <%# photo %>
         <div class="tab-content" id="nav-tabContent">
-          <!-- 全国 -->
+          <%# 全国 %>
           <div class="tab-pane fade show active" id="nav-zenkoku-content" role="tabpanel" aria-labelledby="nav-home-tab" data-bs-target="#nav-zenkoku-content" tabindex="0">
             <div class="row mbr-gallery">
-              <!-- 例 -->
+              <%# 例 %>
               <div class="col-12 col-md-6 col-lg-3 item gallery-image">
                 <%= image_tag("gallery.jpeg", class: "") %>
               </div>
-              <!-- 画像（postの数だけ) -->
+              <%# 画像（postの数だけ) %>
               <% @posts.each do |post| %>
                 <%= render "shared/gallery", post:, facility: post.facility %>
               <% end %>
@@ -95,6 +96,7 @@
     </div>
   </section>
 </div>
+-->
 
 <%= render "shared/footer" %>
 

--- a/app/views/shared/_gallery.html.erb
+++ b/app/views/shared/_gallery.html.erb
@@ -4,7 +4,7 @@
       <%= post.facility.place_name %>
     <% end %>
   </div>
-  <!-- modalのトリガー -->
+  <%# modalのトリガー %>
   <div class="item-wrapper mb-3 modal_click" data-bs-toggle="modal" data-bs-target="#tOiMnQnqDw-modal" data-post-id="<%= post.id %>">
     <%= image_tag(post.images[0], class: "w-100", alt: "No Image",  data: { slide_to: "0", bs_slide_to: "0", target: "#lb-tOiMnQnqDw", bs_target: "#lb-tOiMnQnqDw" }) %>
   </div>
@@ -13,14 +13,14 @@
     <span><%= link_to "投稿者：" + post.user.nickname + "さん", "/users/#{post.user_id}" %></span>
   </div>
 </div>
-<!-- 画像クリック後 -->
+<%# 画像クリック後 %>
 <div class="modal mbr-slider" tabindex="-1" role="dialog" aria-hidden="true"  id="tOiMnQnqDw-modal-<%= post.id %>" data-post-id="<%= post.id %>">
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-body">
         <div class="carousel slide carousel-fade" data-pause="false" data-bs-pause="false" id="lb-tOiMnQnqDw" data-interval="5000" data-bs-interval="5000">
           <div class="carousel-inner">
-            <!-- 複数画像があるとき枚数分(スライド用) -->
+            <%# 複数画像があるとき枚数分(スライド用) %>
             <% post.images.each_with_index do |image,i| %>
               <% if i == 0 %>
                 <div class="carousel-item active">
@@ -33,7 +33,7 @@
               <% end %>
             <% end %>
           </div>
-          <!-- 下の●、複数画像があるとき枚数分(スライド用) -->
+          <%# 下の●、複数画像があるとき枚数分(スライド用) %>
           <ol class="carousel-indicators">
             <li data-slide-to="0" data-bs-slide-to="0" class="active" data-target="#lb-tOiMnQnqDw" data-bs-target="#lb-tOiMnQnqDw"></li>
             <li data-slide-to="1" data-bs-slide-to="1" data-target="#lb-tOiMnQnqDw" data-bs-target="#lb-tOiMnQnqDw"></li>
@@ -41,11 +41,11 @@
             <li data-slide-to="3" data-bs-slide-to="3" data-target="#lb-tOiMnQnqDw" data-bs-target="#lb-tOiMnQnqDw"></li>
             <li data-slide-to="4" data-bs-slide-to="4" data-target="#lb-tOiMnQnqDw" data-bs-target="#lb-tOiMnQnqDw"></li>
           </ol>
-          <!-- 閉じるボタン -->
+          <%# 閉じるボタン %>
           <a role="button" href="" class="close close-modal" data-dismiss="modal" data-bs-dismiss="modal" aria-label="Close">
             <%= image_tag('close.jpeg', class: "", alt: "✕") %>
           </a>
-          <!-- 前へ、次へボタン(1枚のときは表示しない？) -->
+          <%# 前へ、次へボタン(1枚のときは表示しない？) %>
           <a class="carousel-control-prev carousel-control" role="button" data-slide="prev" data-bs-slide="prev" href="#lb-tOiMnQnqDw">
             <span class="carousel-control-prev-icon" aria-hidden="true"></span>
           </a>


### PR DESCRIPTION
#67 
Ransack導入が完了しましたので、ご確認よろしくお願いいたします。

## 実施したこと
- ransack gem導入
- ransack(search_form_for)でとりあえず検索フォームが表示できるところまでモデル・コントローラー対応
- rootページにてsearch_form_forで検索フォームを表示する
- 現状のフォトギャラリーはコメントアウトし、bootstrapなど入っていないシンプルなフォトギャラリーに差し替え

## 実施していないこと
- 実際に検索→検索結果が表示されるかは確認していない（次issue以降実施）
- 今回のテーブル設計がfacility>postというネスト構造で、search_form_forでのビュー作成が難しかったため、イメージはお絵描きソフトでつくりました。（別途issueのコメントでレビュー依頼します）

## ransack導入後のトップページ
![image](https://github.com/ChisatoMatoba/odekake-with-dogs/assets/149556430/48e6fd37-99d3-4e6e-8c0f-6c14d90daced)
