### PR TITLE
都道府県での検索機能

### DIFF
--- a/app/assets/stylesheets/shared/ all.css.erb
+++ b/app/assets/stylesheets/shared/ all.css.erb
@@ -1394,7 +1394,6 @@ a {
 }
 .cid-tOiHBd9Aax {
   padding-top: 6rem;
-  padding-bottom: 6rem;
   background-color: #ffa0a0;
 }
 .cid-tOiHBd9Aax .mbr-fallback-image.disabled {
@@ -1740,4 +1739,13 @@ a {
   background-color: white;
   background-image: url(<%= asset_path('bg_gray.jpg') %>);
   background-repeat: repeat;
+}
+
+.search-form {
+  display: flex;
+  height: auto;
+  width: 80vw !important;
+  flex-direction: column;
+  align-items: center;
+  background-color: #ffcccc;
 }

--- a/app/assets/stylesheets/shared/header.css
+++ b/app/assets/stylesheets/shared/header.css
@@ -22,19 +22,6 @@
   margin-right: 10vw;
 }
 
-.search-form {
-  width: 65vw;
-  height: 5vh;
-  display: flex;
-  margin-bottom: 5px;
-}
-
-.search-form>.input-box {
-  width: 100%;
-  height: 5vh;
-  padding-left: 10px;
-}
-
 .search-button {
   width: 5vh;
   border: 0;

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -39,4 +39,8 @@ class Facility < ApplicationRecord
       %w[沖縄 nav-okinawa-content nav-okinawa-tab]
     end
   end
+
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[category_id created_at id id_value place_name prefecture_id updated_at user_id]
+  end
 end

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -39,28 +39,28 @@
           </div>
         </div>
       </div>
-  </section>
+    </div>
 
-  <!-- 検索フォームセクション -->
-  <section class="gallery1 mbr-gallery cid-tOiHBd9Aax" id="gallery01-1l">
+    <!-- 検索フォームセクション -->
     <div class="container-fluid search-form">
       <!-- title -->
-      <div class="#">
-        <strong>検索フォーム</strong>
+      <div class="mb-3">
+        <span class="bg-color">~検索フォーム~</span>
       </div>
+
       <!-- 検索フォーム -->
-      <div class="#">
+      <div class="w-100">
         <%= search_form_for(@q, url: root_path, method: :get, local: true) do |f| %>
-          <%= f.label :facility_prefecture_id_eq, '都道府県で検索' %>
-          <%= f.collection_select :facility_prefecture_id_eq, Prefecture.all, :id, :name, include_blank: '指定なし' %>
-          <%= f.submit "検索" %>
+          <div class="form-group">
+            <%= f.label :facility_prefecture_id_eq, '都道府県で検索', class: 'form-label' %>
+            <%= f.collection_select :facility_prefecture_id_eq, Prefecture.all, :id, :name, {include_blank: '指定なし'}, {class: 'form-control'} %>
+            <%= f.submit "検索", class: 'btn btn-primary' %>
+          </div>
         <% end %>
       </div>
     </div>
-  </section>
 
-  <!-- 検索結果セクション -->
-  <section data-bs-version="5.1" class="gallery1 mbr-gallery cid-tOiHBd9Aax" id="gallery01-1l">
+    <!-- 検索結果セクション -->
     <!-- photo -->
     <div class="row mbr-gallery">
       <%# 例 %>
@@ -72,7 +72,7 @@
         <%= render "shared/gallery", post:, facility: post.facility %>
       <% end %>
     </div>
-  <section data-bs-version="5.1" class="gallery1 mbr-gallery cid-tOiHBd9Aax" id="gallery01-1l">
+  </section>
 
 <!--
       <%# photo %>
@@ -129,8 +129,7 @@
       </div>
     </div>
   </section>
-</div>
 -->
+</div>
 
 <%= render "shared/footer" %>
-

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -48,11 +48,11 @@
       <div class="#">
         <strong>検索フォーム</strong>
       </div>
-      <!-- 一旦ransackの検索フォームが表示できたことだけ確認 -->
+      <!-- 検索フォーム -->
       <div class="#">
         <%= search_form_for(@q, url: root_path, method: :get, local: true) do |f| %>
-          <%= f.label :name, "Keyword" %>
-          <%= f.search_field :review %>
+          <%= f.label :facility_prefecture_id_eq, '都道府県で検索' %>
+          <%= f.collection_select :facility_prefecture_id_eq, Prefecture.all, :id, :name, include_blank: '指定なし' %>
           <%= f.submit "検索" %>
         <% end %>
       </div>


### PR DESCRIPTION
#69 
都道府県での検索機能が完了しましたので、ご確認よろしくお願いいたします。

## 実施したこと
- 検索フォームに都道府県のセレクトボックスを設置
- 都道府県を選択して「検索」ボタンをクリックすると、その都道府県の施設の投稿が表示される
- 指定なしの場合は全投稿が表示される
- （補足説明）検索フォームにseach-formというクラス名を付けてCSSを新設しました。それに伴い、昔に作成して現在使用しなくなっていた同名のCSS設定を削除しています。

## 実施していないこと
- 地域での検索は次PRで実施予定
- 検索結果の表示は非同期ではなく、ページロードで表示
- 検索結果のビューについては、次PR時に改良予定

## 実行結果

https://github.com/ChisatoMatoba/odekake-with-dogs/assets/149556430/eade8c68-ec0c-43e9-b547-801391011001

