### PR TITLE
投稿についている評価での検索機能

### DIFF
--- a/app/assets/stylesheets/shared/ all.css.erb
+++ b/app/assets/stylesheets/shared/ all.css.erb
@@ -1749,3 +1749,7 @@ a {
   align-items: center;
   background-color: #ffcccc;
 }
+
+.form-label {
+    font-weight: bold;
+}

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -143,5 +143,8 @@ class PostsController < ApplicationController
     selected_condition_ids = params[:q][:facility_conditions_id_in].reject(&:blank?).map(&:to_i)
     @search_conditions['施設の条件'] = Condition.where(id: selected_condition_ids).pluck(:category).join(', ') \
     if selected_condition_ids.present? && !selected_condition_ids.empty?
+
+    # 投稿の満足度
+    @search_conditions['満足度'] = Rating.find_by(id: params[:q][:rating_id_lteq])&.name_with_suffix if params[:q][:rating_id_lteq].present?
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -128,14 +128,8 @@ class PostsController < ApplicationController
       end
   end
 
-  # 適用された検索条件の作成
-  def applied_search_condition
-    # params[:q] が存在しない場合、早期リターン
-    return unless params[:q]
-
-    # 施設の地域・都道府県
-    location_condition
-
+  # 施設のカテゴリー、条件の検索条件を作成
+  def facility_search_conditions
     # 施設のカテゴリー
     @search_conditions['施設のカテゴリー'] = Category.find_by(id: params[:q][:facility_category_id_eq])&.name if params[:q][:facility_category_id_eq].present?
 
@@ -143,7 +137,17 @@ class PostsController < ApplicationController
     selected_condition_ids = params[:q][:facility_conditions_id_in].reject(&:blank?).map(&:to_i)
     @search_conditions['施設の条件'] = Condition.where(id: selected_condition_ids).pluck(:category).join(', ') \
     if selected_condition_ids.present? && !selected_condition_ids.empty?
+  end
 
+  # 適用された検索条件の作成
+  def applied_search_condition
+    # params[:q] が存在しない場合、早期リターン
+    return unless params[:q]
+
+    # 施設の地域・都道府県
+    location_condition
+    # 施設のカテゴリー、条件
+    facility_search_conditions
     # 投稿の満足度
     @search_conditions['満足度'] = Rating.find_by(id: params[:q][:rating_id_lteq])&.name_with_suffix if params[:q][:rating_id_lteq].present?
   end

--- a/app/models/rating.rb
+++ b/app/models/rating.rb
@@ -8,10 +8,5 @@ class Rating < ActiveHash::Base
     { id: 6, name: '★☆☆☆☆' }
   ]
 
-  # 検索の表示用
-  def name_with_suffix
-    "#{name}以上"
-  end
-
   has_many :posts
 end

--- a/app/models/rating.rb
+++ b/app/models/rating.rb
@@ -8,5 +8,10 @@ class Rating < ActiveHash::Base
     { id: 6, name: '★☆☆☆☆' }
   ]
 
+  # 検索の表示用
+  def name_with_suffix
+    "#{name}以上"
+  end
+
   has_many :posts
 end

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -66,6 +66,10 @@
                 <br>
               <% end %>
             </div>
+            <!-- 投稿の満足度 -->
+            <!-- idが小さい方が満足度の星が多くなる様になっているので、'_lteq'で検索 -->
+            <%= f.label :rating_id_lteq, '投稿の満足度', class: 'form-label' %>
+            <%= f.collection_select :rating_id_lteq, Rating.all, :id, :name_with_suffix, {include_blank: '指定なし'}, {class: 'form-control'} %>
             <%= f.submit "検索", class: 'btn btn-primary' %>
           </div>
         <% end %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -69,7 +69,7 @@
             <!-- 投稿の満足度 -->
             <!-- idが小さい方が満足度の星が多くなる様になっているので、'_lteq'で検索 -->
             <%= f.label :rating_id_lteq, '投稿の満足度', class: 'form-label' %>
-            <%= f.collection_select :rating_id_lteq, Rating.all, :id, :name_with_suffix, {include_blank: '指定なし'}, {class: 'form-control'} %>
+            <%= f.collection_select :rating_id_lteq, Rating.all, :id, lambda {|rating| "#{rating.name}以上"}, {include_blank: '指定なし'}, {class: 'form-control'} %>
             <%= f.submit "検索", class: 'btn btn-primary' %>
           </div>
         <% end %>


### PR DESCRIPTION
close #73 
投稿についている評価での検索機能が完了しましたので、ご確認よろしくお願いいたします。

## 実施したこと
- 検索フォームに"★★★☆☆以上"などのセレクトボックスを作成し、選択して検索すると、その★の数以上の評価がついている投稿を表示する
- 他のセレクトボックスとはAND条件で検索する
- 指定なしの場合は、すべての投稿を結果として返す
（地域：東北、カテゴリー：指定なし、条件：選択なし、満足度：指定なし
　→　"東北"のすべての投稿を結果として表示）

## 実施していないこと
- 検索結果の表示は非同期ではなく、ページロードで表示

## 実行結果

https://github.com/ChisatoMatoba/odekake-with-dogs/assets/149556430/f4c21db7-1b6f-4614-a63c-cee3a77cdd22

