### PR TITLE
ビューの軽微修正

### DIFF
--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -111,7 +111,7 @@
         <% if @posts.present? %>
           <%# 例 %>
           <div class="col-12 col-md-6 col-lg-3 item gallery-image">
-            <%= image_tag("gallery.jpeg", class: "") %>
+            <%= image_tag("gallery.jpeg", class: "card border-warning border-4") %>
           </div>
           <%# 画像（postの数だけ) %>
           <% @posts.each do |post| %>

--- a/app/views/shared/_gallery.html.erb
+++ b/app/views/shared/_gallery.html.erb
@@ -1,5 +1,5 @@
 <div class="col-12 col-md-6 col-lg-3 item gallery-image">
-  <div class="mbr-item-subtitle mbr-fonts-style align-center mb-0 mt-3 display-7">
+  <div class="mbr-item-subtitle mbr-fonts-style align-center mb-0 mt-3 mb-2 display-7">
     <%= link_to facility_post_path(facility, post) do %>
       <%= post.facility.place_name %>
     <% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -29,7 +29,7 @@
           <li class="nav-link ms-auto">
             <ul style="display: flex;">
               <% if user_signed_in? %>
-                <li><br>こんにちは！<br><%= link_to current_user.nickname, "/users/#{current_user.id}", class: "btn-link display-7" %>さん</li>
+                <li>こんにちは！<br><%= link_to current_user.nickname, "/users/#{current_user.id}", class: "btn-link display-7" %>さん</li>
                 <li><%= link_to '施設一覧・新規投稿', facilities_path, data: { turbo: false }, class: 'btn btn-warning display-7' %></li>
                 <li><%= link_to 'ログアウト', destroy_user_session_path, data: { turbo_method: :delete }, class: "btn btn-secondary display-7" %></li>
               <% else %>


### PR DESCRIPTION
ビューの軽微修正が完了しましたので、ご確認よろしくお願いいたします。

## 実施したこと
- ヘッダの要素の高さを揃える
- 施設名と画像の隙間を少し開ける
- 例を境界線で囲む（例は画像と注釈を１つのイメージとして読み込んでいるので、高さが違う問題を解決するのは難しく、黄色で囲うことで特別感を出してごまかしました…。）

### 修正前
![image](https://github.com/ChisatoMatoba/odekake-with-dogs/assets/149556430/f800e5df-c152-4d61-b9ed-e04490f2cc9e)

### 修正後
![image](https://github.com/ChisatoMatoba/odekake-with-dogs/assets/149556430/baa47ff1-985b-42f3-b116-449b63674a35)
